### PR TITLE
Some edits to the README and sample JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Cloud.gov PHP Example Application:  Wordpress
+## Cloud.gov PHP Example Application:  WordPress
 
 This is an example application which can be run on Cloud.gov using the CloudFoundry [PHP Build Pack].
 
-This is an out-of-the-box implementation of Wordpress.  It's an example of how common PHP applications can easily be run on Cloud.gov
+This is an out-of-the-box implementation of WordPress.  It's an example of how common PHP applications can easily be run on Cloud.gov
 
 ### Usage
 
@@ -33,21 +33,21 @@ This is an out-of-the-box implementation of Wordpress.  It's an example of how c
      * Example: `cf create-service s3 basic s3-service`
 
 4. Copy the example `manifest.yml.example` to `manifest.yml`. Edit the `manifest.yml` file.
-  * Change the 'host' attribute to something unique for your site.
+  * Change the 'name' and 'host' attributes to something unique for your site.
   * Under "services:" change
     * "mysql-service" to the name of your MySQL service you created in Step 2.
     * "s3-storage" to the name of your S3 service you created in Step 3. Or delete this line if you're not using S3.
 
 5. Copy the example `setup.json.example` to `setup.json`. Edit the `setup.json` file for your specific WordPress site information, plugins you want installed, and themes.
-  * **NOTE** The example includes a set of plugins that will be used to attach to your previously created S3 storage so you can store media uploads, like pictures, for your WordPress site. If you do not use these plugins, every time you deploy, it will destroy your uploaded files. 
+  * **NOTE** The example includes a set of plugins that will be used to attach to your previously created S3 storage so you can store media uploads, like pictures, for your WordPress site. If you do not use these plugins, every time you deploy, it will destroy your uploaded files.
   * See: [Setup JSON](#setup-json) for more information about the format of this file
 
 6. Deploy the app with a no start command
 `cf push --no-start`
 
-7. Set environment variables for secret keys using [Wordpress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/).
+7. Set environment variables for secret keys using [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/).
 
-You will likely need to remove "bad" characters that break bash environment variable parsing: '`' (backtick), ' ', (space), and ';' (semicolon).
+Make sure to include the leading and closing `'` characters to avoid errors escaping special characters.
 
   ```bash
   cf set-env mywordpress AUTH_KEY YOUR_KEY
@@ -88,12 +88,12 @@ The only required section is `site_info`
 ```
 This section is used to setup your WordPress site for the first time. You can change most of these settings with the WordPress admin once you have logged in after setup.
 
-You can define a specific version of WordPress that you would like to use with `wordpress_version`. If you do not specify, it will use the latest release of WordPress.
+You can define a specific version of WordPress that you would like to use by adding `"wordpress_version": VERSION_NUMBER` on line above the "site_info" section. If you don't add this line, cloud.gov will use the latest release of WordPress.
 
 Plugins and themes are configured in the same way. You can provide either:
  * `name` and specific `version`
  * `name` only and latest version will be used
- * `url` only
+ * `url` only (if you want to add a plugin from GitHub that's not in the Plugin repository)
 
 #### Full Example
 ```json
@@ -131,14 +131,14 @@ Plugins and themes are configured in the same way. You can provide either:
 
 When you push the application here's what happens.
 
-1. The local bits are pushed to your target.  This is small, five files around 25k. It includes the changes we made and a build pack extension for Wordpress.
+1. The local bits are pushed to your target.  This is small, five files around 25k. It includes the changes we made and a build pack extension for WordPress.
 1. The server downloads the [PHP Build Pack] and runs it.  This installs HTTPD and PHP.
-1. The build pack sees the extension that we pushed and runs it.  The extension installs [wpcli](http://wp-cli.org/), and then reads your `setup.json` to install WordPress, and any plugins or themes you have defined. It then copies the rest of the files that we pushed and replaces the default Wordpress files with them.  In this case, it's just the `wp-config.php` file.
+1. The build pack sees the extension that we pushed and runs it.  The extension installs [wpcli](http://wp-cli.org/), and then reads your `setup.json` to install WordPress, and any plugins or themes you have defined. It then copies the rest of the files that we pushed and replaces the default WordPress files with them.  In this case, it's just the `wp-config.php` file.
 1. At this point, the build pack is done and CF runs our droplet.
 
 ### Changes
 
-These changes were made to prepare Wordpress to run on CloudFoundry.
+These changes were made to prepare WordPress to run on CloudFoundry.
 
 1. Edit `wp-config.php`, configure to use CloudFoundry database.
 
@@ -176,11 +176,11 @@ These changes were made to prepare Wordpress to run on CloudFoundry.
 
 ### Caution
 
-Please read the following before using Wordpress in production on CloudFoundry.
+Please read the following before using WordPress in production on CloudFoundry.
 
-1. Wordpress is designed to write to the local file system.  This does not work well with CloudFoundry, as an application's [local storage on CloudFoundry] is ephemeral.  In other words, Wordpress will write things to the local disk and they will eventually disappear. Using S3 for media upload storage is the recommended way to rectify this at this time. Also, keep in mind, that if you install themes or plugins via the WordPress admin and you have not included them in your `setup.json`, the next time you push, these plugins or themes will be removed.
+1. WordPress is designed to write to the local file system.  This does not work well with CloudFoundry, as an application's [local storage on CloudFoundry] is ephemeral.  In other words, WordPress will write things to the local disk and they will eventually disappear. Using S3 for media upload storage is the recommended way to rectify this at this time. Also, keep in mind, that if you install themes or plugins via the WordPress admin and you have not included them in your `setup.json`, the next time you push, these plugins or themes will be removed.
 
-1. This is not an issue with Wordpress specifically, but PHP stores session information to the local disk.  As mentioned previously, the local disk for an application on CloudFoundry is ephemeral, so it is possible for you to lose session and session data.  If you need reliable session storage, look at storing session data in an SQL database or with a NoSQL service.
+1. This is not an issue with WordPress specifically, but PHP stores session information to the local disk.  As mentioned previously, the local disk for an application on CloudFoundry is ephemeral, so it is possible for you to lose session and session data.  If you need reliable session storage, look at storing session data in an SQL database or with a NoSQL service.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Cloud.gov PHP Example Application:  WordPress
+## cloud.gov PHP Example Application:  WordPress
 
-This is an example application which can be run on Cloud.gov using the CloudFoundry [PHP Build Pack].
+This is an example application which can be run on cloud.gov using the CloudFoundry [PHP buildpack](http://docs.cloudfoundry.org/buildpacks/php/index.html).
 
-This is an out-of-the-box implementation of WordPress.  It's an example of how common PHP applications can easily be run on Cloud.gov
+This is an out-of-the-box implementation of WordPress. It's an example of how common PHP applications can easily be run on cloud.gov
 
 1. [Installation](#installation)
 1. [Administering your WordPress site](#administering-you-wordpress-site)
@@ -30,7 +30,7 @@ This is an out-of-the-box implementation of WordPress.  It's an example of how c
 
 3. Create a service instance of S3 storage.
 
-cloud.gov does not have persistent local storage so you'll need to rely on S3 for storing any files uploaded to WordPress. Sandbox accounts cannot create S3 storage services, consider upgrading to a prototyping package if you need to do this.
+cloud.gov does not have persistent local storage so you'll need to rely on S3 for storing any files uploaded to WordPress. Sandbox accounts cannot create S3 storage services. Consider upgrading to a prototyping package if you need to do this.
 
   * View Services
      * `cf marketplace`
@@ -49,12 +49,12 @@ cloud.gov does not have persistent local storage so you'll need to rely on S3 fo
   * The memory and disk allocations in the example `manifest.yml` file should be [sufficient for WordPress](https://codex.wordpress.org/Editing_wp-config.php#Increasing_memory_allocated_to_PHP) but may need to be adjusted depending on your specific needs.
 
 5. Copy the example `setup.json.example` to `setup.json`. Edit the `setup.json` file for your specific WordPress site information, plugins you want installed, and themes.
-  * **NOTE** The example includes a set of plugins that will be used to attach to your previously created S3 storage so you can store media uploads, like pictures, for your WordPress site. If you do not use these plugins, every time you deploy, it will destroy your uploaded files.
+  * **NOTE** The example includes a set of plugins that will be used to attach to your previously created S3 storage so you can store media uploads, like pictures, for your WordPress site. If you do not use these plugins, every time you deploy, uploaded files will be lost.
   * See: [Setup JSON](#setup-json) for more information about the format of this file
 
 6. Deploy the app with a no start command with`cf push --no-start`
 
-This will download and install WordPress, your MySQL database, and all plugins but will not start the application on cloud.gov.
+This will download and install WordPress, configure it to use your MySQL service, and install all your plugins and themes but will not start the application on cloud.gov.
 
 7. Set environment variables for secret keys using [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/).
 
@@ -79,7 +79,7 @@ Run:
   cf push
   ```
 
-This will push the files in this repository to the platform (around 25k), including the buildpack extension we've adapted from the Cloud Foundry project. The server downloads and runs the [PHP Build Pack] which installs HTTPD and PHP. The buildpack sees the extension which installs [wpcli](http://wp-cli.org/), reads your `setup.json`, and installs and configures WordPress along with any plugins or themes you have defined. It then copies the `wp-config.php` file and replaces the default WordPress files with it. Once all that is finished, the platform starts the droplet and you have a WordPress site.
+This will push the files in this repository to the platform (around 25k), including the buildpack extension we've adapted from the Cloud Foundry project. The server downloads and runs the [PHP buildpack](http://docs.cloudfoundry.org/buildpacks/php/index.html) which installs HTTPD and PHP. The buildpack sees the extension which installs [WP-CLI](http://wp-cli.org/), reads your `setup.json`, and installs and configures WordPress with any plugins or themes you have defined. Then it copies the `wp-config.php` file to replace the default from WordPress. Once all that is finished, the platform starts the application. Now you have a WordPress site.
 
 You should see output like this in your terminal:
 
@@ -91,7 +91,7 @@ You should see output like this in your terminal:
 
   App mywordpress was started using this command `$HOME/.bp/bin/start`
 
-  Showing health and status for app mywordpress in org sandbox-gsa / space gregory.boone as gregory.boone@gsa.gov...
+  Showing health and status for app mywordpress in org sandbox-gsa / space your.name as your.name@agency.gov...
   OK
 
   requested state: started
@@ -108,7 +108,7 @@ If you go to the URL listed under `urls` you should see a fresh WordPress site.
 
 9. Verify S3 connection
 
-This demo uses the [Human Made S3 Uploads plugin](https://github.com/humanmade/S3-Uploads), which automatically uploads files from your WordPress install to S3 and rewrites the URLs for you. The app has no configuration, the access keys, secret key, and bucket name are stored in the environment configuration and read by the plugin on start.
+This demo uses the [Human Made S3 Uploads plugin](https://github.com/humanmade/S3-Uploads), which automatically uploads files from your WordPress install to S3 and rewrites the URLs for you. The app requires no configuration. The access keys, secret key, and bucket name are stored in the environment configuration and read by the plugin on start.
 
 ```
 cf run-task gb-learns-cloud "php/bin/php htdocs/wp-cli.phar s3-uploads verify --path='/home/vcap/app/htdocs/'"
@@ -120,9 +120,9 @@ To see that the task ran, run `cf logs APP_NAME --recent` and you should see a l
 OUT Success: Looks like your configuration is correct.
 ```
 
-10. Log in and create a test post with media
+10. Log in and test
 
-To test everything is correct, log in to your WordPress site with the credentials in your `setup.json` file. You should be able to do any admin activities including creating a new post and add an uploaded media file to it.
+To test everything is correct, log in to your WordPress site with the credentials in your `setup.json` file. You should be able to do any admin activities including creating a new post and uploading a media file to it.
 
 ### Administering your WordPress site
 
@@ -148,9 +148,9 @@ Make sure you change these values, especially `url` and `title` to something spe
 
 #### Updating WordPress
 
-By default, this package will install the latest version of WordPress. To update, run `cf restage APP_NAME`. cloud.gov will install a fresh copy of WordPress Core each time you `push` or `restage` so we **do not recommend** using the admin interface to manage updates to your site.
+By default, this package will install the latest version of WordPress. To update WordPress or pick up a new version of the PHP builpack, [run `cf restage APP_NAME`](https://cloud.gov/docs/getting-started/app-maintenance/). cloud.gov will install a fresh copy of WordPress Core each time you `push` or `restage`. We **do not recommend** using the wp-admin interface to manage updates to your site.
 
-If you want to pin your Core installation to a specific version of WordPress that you can. Add `"wordpress_version": VERSION_NUMBER` on line above the `site_info` section.
+If you want to pin your Core installation to a specific version of WordPress, add `"wordpress_version": VERSION_NUMBER` on a line above the `site_info` section.
 
 ```json
 {
@@ -166,7 +166,7 @@ If you want to pin your Core installation to a specific version of WordPress tha
 
 The Cloud Foundry platform builds apps with ephemeral local storage. This means any changes made to local files on your app will get deleted whenever you `push` or `restage` the app. Make sure your plugins and themes remain installed by installing them through the `plugins` and `themes` sections of the `setup.json` file.
 
-For plugins or themes you'd normally be able to install from the admin interface, you can list them by name and the version that you want installed. For anything not available through WordPress directly, provide a URL to a ZIP file. For example, if your site's theme is one you've developed custom, you can host it on GitHub and use the "Download ZIP" link to install it.
+For plugins or themes you'd normally be able to install from the admin interface, you can list them by name and the version that you want installed. For anything not available through WordPress directly, provide a URL to a ZIP file. For example, if your site's theme is one you've custom-developed, you can host it on GitHub and use the "Download ZIP" link to install it.
 
 ```json
 "plugins": [
@@ -189,7 +189,7 @@ For plugins or themes you'd normally be able to install from the admin interface
   ]
 ```
 
-In the sample `setup.json` file you see three plugins installed by default. One from GitHub and two from WordPress, one of which is pinned to a specfic version. As with WordPress Core, if you pin the version, make sure to watch for and install updates that contain security fixes.
+In the sample `setup.json` file you see three plugins installed by default. One from GitHub and two from WordPress, one of which is pinned to a specific version. As with WordPress Core, if you pin the version, make sure to watch for and install updates that contain security fixes.
 
 #### Running WP-CLI commands
 
@@ -222,7 +222,7 @@ Run `cf logs APP_NAME --recent` to see the results and look for the `task name` 
 2017-09-27T10:54:52.92-0600 [APP/TASK/98680974/0] OUT Successfully destroyed container
 ```
 
-Consider using continuous integration to run any tasks that should be run every time you `push` or `restage` your app.
+Consider using [continuous integration](https://cloud.gov/docs/apps/continuous-deployment/) to run any tasks that should be run every time you `push` or `restage` your app or that you want to run at regular time intervals.
 
 
 ### Full example setup.json file
@@ -230,7 +230,7 @@ Consider using continuous integration to run any tasks that should be run every 
 {
   "wordpress_version": "4.4",
   "site_info": {
-    "url": "https://mysite.app.cloud.gov",
+    "url": "https://CHANGEME.app.cloud.gov",
     "title": "My new site",
     "admin_user": "admin",
     "admin_password": "CHANGEME",
@@ -256,15 +256,15 @@ Consider using continuous integration to run any tasks that should be run every 
 
 ### Recommendations
 
-1. You will probably want to connect your app to some kind of SMTP service to send transactional emails like password resets. By default cloud.gov apps cannot send email.
-1. The S3 Uploads plugin rewrites the URLs used by WordPress but does not flush the rewrite rules table automatically. To get around this, you can run a task to flush the rewrite rules after every `cf push` of your app. You can also automate those tasks by integrating continuous integration into your app.
+1. You will probably want to connect your app to some kind of SMTP service to send transactional emails like password resets.
+1. The S3 Uploads plugin rewrites the URLs used by WordPress but does not flush the rewrite rules table automatically. To get around this, you can [run a task](https://cloud.gov/docs/getting-started/one-off-tasks/) to flush the rewrite rules after every `cf push` of your app. You can also automate those tasks by using [continuous integration](https://cloud.gov/docs/apps/continuous-deployment/).
 
 ### License
 
 See [LICENSE](LICENSE.md) for license details.
 
 
-[PHP Build Pack]:https://github.com/cloudfoundry/php-buildpack
+[PHP buildpack](http://docs.cloudfoundry.org/buildpacks/php/index.html):https://github.com/cloudfoundry/php-buildpack
 [secret keys]:https://github.com/cloudfoundry-samples/cf-ex-wordpress/blob/master/wp-config.php#L49
 [WordPress.org secret-key service]:https://api.wordpress.org/secret-key/1.1/salt
 [ClearDb]:https://www.cleardb.com/

--- a/setup.json.example
+++ b/setup.json.example
@@ -1,5 +1,4 @@
 {
-    "wordpress_version": "4.4",
     "site_info": {
         "url": "https://mysite.app.cloud.gov",
         "title": "My new site",

--- a/setup.json.example
+++ b/setup.json.example
@@ -1,6 +1,6 @@
 {
     "site_info": {
-        "url": "https://mysite.app.cloud.gov",
+        "url": "https://CHANGEME.app.cloud.gov",
         "title": "My new site",
         "admin_user": "admin",
         "admin_password": "CHANGEME",

--- a/setup.json.example
+++ b/setup.json.example
@@ -8,12 +8,14 @@
     },
     "plugins": [
         {
-            "name": "amazon-web-services",
-            "version": "0.3.4"
+          "url": "https://github.com/humanmade/S3-Uploads/archive/v1.1.0.zip"
         },
         {
-            "name": "amazon-s3-and-cloudfront",
-            "version": "0.9.10"
+          "name": "akismet",
+          "version": "4.0"
+        },
+        {
+          "name": "hello-dolly"
         }
     ],
     "themes": [

--- a/wp-config.php
+++ b/wp-config.php
@@ -56,15 +56,13 @@ define('DB_COLLATE', '');
  define('NONCE_SALT', $_ENV['NONCE_SALT']);
 /**#@-*/
 
-/** S3 Access Keys **/
- $s3service = $services['s3'][0]; // pick the first S3 service
- define( 'AWS_ACCESS_KEY_ID', $s3service['credentials']['access_key_id'] );
- define( 'AWS_SECRET_ACCESS_KEY', $s3service['credentials']['secret_access_key'] );
- define( 'AS3CF_BUCKET', $s3service['credentials']['bucket'] );
- define( 'AS3CF_ASSETS_BUCKET', $s3service['credentials']['bucket'] );
-
- /** **/
-
+/** S3 Uploads Keys **/
+$s3service = $services['s3'][0]; // pick the first S3 service
+define( 'S3_UPLOADS_BUCKET', $s3service['credentials']['bucket'] );
+define( 'S3_UPLOADS_KEY', $s3service['credentials']['access_key_id'] );
+define( 'S3_UPLOADS_SECRET', $s3service['credentials']['secret_access_key'] );
+define( 'S3_UPLOADS_REGION', $s3service['credentials']['region'] );
+define( 'S3_UPLOADS_BUCKET_URL', "https://s3-" . $s3service['credentials']['region'] . ".amazonaws.com/" . $s3service['credentials']['bucket'] );
 /**
  * WordPress Database Table prefix.
  *
@@ -90,7 +88,7 @@ define('WPLANG', '');
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
  */
-define('WP_DEBUG', false);
+define('WP_DEBUG', true);
 
 /* That's all, stop editing! Happy blogging. */
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -88,7 +88,7 @@ define('WPLANG', '');
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
  */
-define('WP_DEBUG', true);
+define('WP_DEBUG', false);
 
 /* That's all, stop editing! Happy blogging. */
 


### PR DESCRIPTION
* properly capitalizes WordPress ;) in the README
* Clarifies some otherwise confusing wording
* Removes the `wordpress_version` line from the example setup JSON