### PR TITLE
Update WP Install for PHP 7

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -1,3 +1,12 @@
 {
-    "ADMIN_EMAIL": "dan@mikusa.com"
+    "PHP_EXTENSIONS": [
+        "mysqli",
+        "openssl",
+        "mbstring",
+        "gd",
+        "zip",
+        "curl",
+        "sockets",
+        "zlib"
+    ]
 }

--- a/.bp-config/php/php.ini.d/wordpress.ini
+++ b/.bp-config/php/php.ini.d/wordpress.ini
@@ -1,6 +1,6 @@
 extension=mbstring.so
 extension=mysqli.so
-extension=mcrypt.so
+#extension=mcrypt.so
 extension=gd.so
 extension=zip.so
 extension=curl.so

--- a/.cfignore
+++ b/.cfignore
@@ -2,3 +2,4 @@
 manifest.yml
 README.md
 test.lp
+setup.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .ssh
 test.lp
 setup.json
+setup.sh
+manifest.yml

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cloud.gov does not have persistent local storage so you'll need to rely on S3 fo
 
 This will download and install WordPress, configure it to use your MySQL service, and install all your plugins and themes but will not start the application on cloud.gov.
 
-7. Copy the example `setup.sh.example` to `setup.sh` and replace the placeholder `YOUR-KEY` with the values from the [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/). Make sure to `chomd +x` the file, and then run it: `./setup.sh`. This will set these values as environmental values in the cloud.gov environment. Note - Make sure to include the leading and closing `'` characters to avoid errors escaping special characters.
+7. Copy the example `setup.sh.example` to `setup.sh` and replace the placeholder `YOUR-KEY` with the values from the [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/). Make sure to `chomd +x` the file, and then run it and pass in the name of your app: `./setup.sh mywordpress`. This will set these values as environmental values in the cloud.gov environment. Note - Make sure to include the leading and closing `'` characters to avoid errors escaping special characters.
 
 8. Push it to CloudFoundry.
 

--- a/README.md
+++ b/README.md
@@ -56,20 +56,7 @@ cloud.gov does not have persistent local storage so you'll need to rely on S3 fo
 
 This will download and install WordPress, configure it to use your MySQL service, and install all your plugins and themes but will not start the application on cloud.gov.
 
-7. Set environment variables for secret keys using [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/).
-
-Make sure to include the leading and closing `'` characters to avoid errors escaping special characters.
-
-  ```bash
-  cf set-env mywordpress AUTH_KEY YOUR_KEY
-  cf set-env mywordpress SECURE_AUTH_KEY YOUR_KEY
-  cf set-env mywordpress LOGGED_IN_KEY YOUR_KEY
-  cf set-env mywordpress NONCE_KEY YOUR_KEY
-  cf set-env mywordpress AUTH_SALT YOUR_KEY
-  cf set-env mywordpress SECURE_AUTH_SALT YOUR_KEY
-  cf set-env mywordpress LOGGED_IN_SALT YOUR_KEY
-  cf set-env mywordpress NONCE_SALT YOUR_KEY
-  ```
+7. Copy the example `setup.sh.example` to `setup.sh` and replace the placeholder `YOUR-KEY` with the values from the [WordPress Secret Key Generator](https://api.wordpress.org/secret-key/1.1/salt/). Make sure to `chomd +x` the file, and then run it: `./setup.sh`. This will set these values as environmental values in the cloud.gov environment. Note - Make sure to include the leading and closing `'` characters to avoid errors escaping special characters.
 
 8. Push it to CloudFoundry.
 

--- a/manifest.yml.example
+++ b/manifest.yml.example
@@ -2,7 +2,7 @@
 applications:
 - name: mywordpress
   memory: 128M
-  disk_quota: 250M
+  disk_quota: 512M
   path: .
   buildpack: php_buildpack
   host: my-special-wordpress

--- a/setup.sh.example
+++ b/setup.sh.example
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cf set-env cg-wordpress-demo AUTH_KEY YOUR-KEY
+cf set-env cg-wordpress-demo SECURE_AUTH_KEY YOUR-KEY
+cf set-env cg-wordpress-demo LOGGED_IN_KEY YOUR-KEY
+cf set-env cg-wordpress-demo NONCE_KEY YOUR-KEY
+cf set-env cg-wordpress-demo AUTH_SALT YOUR-KEY
+cf set-env cg-wordpress-demo SECURE_AUTH_SALT YOUR-KEY
+cf set-env cg-wordpress-demo LOGGED_IN_SALT YOUR-KEY
+cf set-env cg-wordpress-demo NONCE_SALT YOUR-KEY

--- a/setup.sh.example
+++ b/setup.sh.example
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-cf set-env cg-wordpress-demo AUTH_KEY YOUR-KEY
-cf set-env cg-wordpress-demo SECURE_AUTH_KEY YOUR-KEY
-cf set-env cg-wordpress-demo LOGGED_IN_KEY YOUR-KEY
-cf set-env cg-wordpress-demo NONCE_KEY YOUR-KEY
-cf set-env cg-wordpress-demo AUTH_SALT YOUR-KEY
-cf set-env cg-wordpress-demo SECURE_AUTH_SALT YOUR-KEY
-cf set-env cg-wordpress-demo LOGGED_IN_SALT YOUR-KEY
-cf set-env cg-wordpress-demo NONCE_SALT YOUR-KEY
+APP_NAME=$1
+
+cf set-env $APP_NAME AUTH_KEY YOUR-KEY
+cf set-env $APP_NAME SECURE_AUTH_KEY YOUR-KEY
+cf set-env $APP_NAME LOGGED_IN_KEY YOUR-KEY
+cf set-env $APP_NAME NONCE_KEY YOUR-KEY
+cf set-env $APP_NAME AUTH_SALT YOUR-KEY
+cf set-env $APP_NAME SECURE_AUTH_SALT YOUR-KEY
+cf set-env $APP_NAME LOGGED_IN_SALT YOUR-KEY
+cf set-env $APP_NAME NONCE_SALT YOUR-KEY

--- a/wp-config.php
+++ b/wp-config.php
@@ -18,6 +18,8 @@
 $services = json_decode($_ENV['VCAP_SERVICES'], true);
 $service = $services['aws-rds'][0];  // pick the first MySQL service
 
+define('WP_USE_EXT_MYSQL', false);
+
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
 define('DB_NAME', $service['credentials']['db_name']);


### PR DESCRIPTION
This commit updates this repo for PHP 7. Specifically, it makes the following changes:

* Removes the `mcrypt` module from the list of modules enabled, as this was removed from PHP 7 which is used by the PHP buildpack.
* Ensures that Wordpress uses `mysqli_connect()` when connecting to the RDS, rather than `mysql_connect()` which is deprecated in PHP 7.

Other changes:
* Increased default disk allocation to avoid running out of space when installing Wordpress.
* Added bash script to set env variables.