### PR TITLE
Install S3 Uploads plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ This is an out-of-the-box implementation of WordPress. It's an example of how co
     This demo uses the [Human Made S3 Uploads plugin](https://github.com/humanmade/S3-Uploads), which automatically uploads files from your WordPress install to S3 and rewrites the URLs for you. The app requires no configuration. The access keys, secret key, and bucket name are stored in the environment configuration and read by the plugin on start.
 
     ```shell
-    # for CF CLI v7
-    cf run-task mywordpress "wp s3-uploads verify --path='/home/vcap/app/htdocs/'"
-    # for CF CLI v8
     cf run-task mywordpress --command "wp s3-uploads verify --path='/home/vcap/app/htdocs/'"
     ```
 
@@ -175,9 +172,6 @@ As with WordPress Core, make sure to watch for and install updates for the plugi
 We recommend using Cloud Foundry's "tasks" to run `wp-cli` commands. To do this, make sure to specify the WordPress path relative to the `app` directory. Here's how you would run `wp core version` on your cloud.gov container:
 
 ```bash
-# for CF CLI v7
-cf run-task APP_NAME "wp core version --path='/home/vcap/app/htdocs/'"
-# for CF CLI v8
 cf run-task APP_NAME --command "wp core version --path='/home/vcap/app/htdocs/'"
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "wpackagist-plugin/akismet": "^5.2",
     "wpackagist-theme/create": "^2.9",
     "wp-cli/wp-cli": "^2.8",
-    "wp-cli/core-command": "^2.1"
+    "wp-cli/core-command": "^2.1",
+    "wp-cli/extension-command": "^2.1"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bf8206632cc59e5d7353198582ec3c2",
+    "content-hash": "b94e55811f765f4751da1498ff5001df",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1500,6 +1500,104 @@
                 "source": "https://github.com/wp-cli/core-command/tree/v2.1.14"
             },
             "time": "2023-07-13T12:05:43+00:00"
+        },
+        {
+            "name": "wp-cli/extension-command",
+            "version": "v2.1.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/extension-command.git",
+                "reference": "e92390ce3a0d95f534ab6c88f9a77bfd4615de47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/e92390ce3a0d95f534ab6c88f9a77bfd4615de47",
+                "reference": "e92390ce3a0d95f534ab6c88f9a77bfd4615de47",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4 || ^2 || ^3",
+                "wp-cli/wp-cli": "^2.5.1"
+            },
+            "require-dev": {
+                "wp-cli/cache-command": "^2.0",
+                "wp-cli/entity-command": "^1.3 || ^2",
+                "wp-cli/language-command": "^2.0",
+                "wp-cli/scaffold-command": "^1.2 || ^2",
+                "wp-cli/wp-cli-tests": "^3.1"
+            },
+            "type": "wp-cli-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                },
+                "bundled": true,
+                "commands": [
+                    "plugin",
+                    "plugin activate",
+                    "plugin deactivate",
+                    "plugin delete",
+                    "plugin get",
+                    "plugin install",
+                    "plugin is-installed",
+                    "plugin list",
+                    "plugin path",
+                    "plugin search",
+                    "plugin status",
+                    "plugin toggle",
+                    "plugin uninstall",
+                    "plugin update",
+                    "theme",
+                    "theme activate",
+                    "theme delete",
+                    "theme disable",
+                    "theme enable",
+                    "theme get",
+                    "theme install",
+                    "theme is-installed",
+                    "theme list",
+                    "theme mod",
+                    "theme mod get",
+                    "theme mod set",
+                    "theme mod remove",
+                    "theme path",
+                    "theme search",
+                    "theme status",
+                    "theme update",
+                    "theme mod list"
+                ]
+            },
+            "autoload": {
+                "files": [
+                    "extension-command.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@runcommand.io",
+                    "homepage": "https://runcommand.io"
+                },
+                {
+                    "name": "Alain Schlesser",
+                    "email": "alain.schlesser@gmail.com",
+                    "homepage": "https://www.alainschlesser.com"
+                }
+            ],
+            "description": "Manages plugins and themes, including installs, activations, and updates.",
+            "homepage": "https://github.com/wp-cli/extension-command",
+            "support": {
+                "issues": "https://github.com/wp-cli/extension-command/issues",
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.13"
+            },
+            "time": "2023-04-04T21:39:30+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -28,3 +28,9 @@ if ! wp core is-installed --path="$WEBROOT"; then
     --admin_email="$ACCOUNT_EMAIL" \
     --admin_password="$ACCOUNT_PASS"
 fi
+
+if ! wp plugin is-active s3-uploads --path="$WEBROOT"; then
+  echo "Activating S3 Uploads plugin"
+  wp plugin activate s3-uploads \
+    --path="$WEBROOT/"
+fi


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add `wp-cli/extension-command` to allow managing plugins/themes using the WP CLI
- Fix README examples for `cf run-task`
- Update bootstrap script to install S3 Uploads plugin

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing example repo so it works out of the box
